### PR TITLE
Bumps `effectful-core` version bounds

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -5,4 +5,4 @@ with-compiler: ghc-8.10
 source-repository-package
   type: git
   location: https://github.com/haskell-effectful/time-effectful.git
-  tag: 3888f3e
+  tag: f2ab73fc1c19bac7c955059ca898d8fd15157054

--- a/cabal.project
+++ b/cabal.project
@@ -5,4 +5,4 @@ with-compiler: ghc-8.10
 source-repository-package
   type: git
   location: https://github.com/haskell-effectful/time-effectful.git
-  tag: f2ab73fc1c19bac7c955059ca898d8fd15157054
+  tag: e212239b685e1ecf7ee95dd1e944cc563351907f

--- a/log-effectful.cabal
+++ b/log-effectful.cabal
@@ -41,7 +41,7 @@ library
     , aeson
     , base            <=4.17
     , bytestring
-    , effectful-core  ^>=1.0.0.0
+    , effectful-core  ^>=2.1.0.0
     , log-base        >=0.11.0.0
     , text
     , time

--- a/log-effectful.cabal
+++ b/log-effectful.cabal
@@ -41,7 +41,7 @@ library
     , aeson
     , base            <=4.17
     , bytestring
-    , effectful-core  ^>=2.1.0.0
+    , effectful-core  >=1.0 && <2.2
     , log-base        >=0.11.0.0
     , text
     , time


### PR DESCRIPTION
Pushed it  (and reverted) by mistake to `master` 🙁 

~~Currently tracks a similar time-effectful [PR](https://github.com/haskell-effectful/time-effectful/pull/4)~~